### PR TITLE
build: 更新项目版本并配置 Windows 构建发布

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "electron-app",
-  "version": "1.0.2",
+  "version": "1.0.0",
   "main": "dist-electron/main/main.js",
   "description": "Electron + Vite + React + Tailwindcss",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build && electron-builder",
-    "build:win": "tsc && vite build && electron-builder --win",
+    "build:win": "tsc && vite build && electron-builder --win --config --publish always",
     "build:mac": "tsc && vite build && electron-builder --mac",
     "start": "electron .",
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
- 将项目版本从 1.0.2 降级到 1.0.0
- 在 Windows 构建命令中添加 --config 和 --publish always 参数