### PR TITLE
ci(release): 添加 GitHub Actions 发布流程

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - "v*" # 推送以 v 开头的标签时触发工作流，例如 v1.0.0, v1.0.1
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest] # 定义构建平台
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20 # 建议使用 18 或更高的 LTS 版本
+
+      - name: Install dependencies
+        run: yarn install # 或使用 pnpm, yarn
+
+      - name: Build and publish Electron app
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }} # 使用 GitHub 自动提供的 Token
+        run: yarn run build:win # 或者根据需要使用 build:mac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,4 @@ jobs:
         run: yarn install # 或使用 pnpm, yarn
 
       - name: Build and publish Electron app
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }} # 使用 GitHub 自动提供的 Token
         run: yarn run build:win # 或者根据需要使用 build:mac

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-app",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist-electron/main/main.js",
   "description": "Electron + Vite + React + Tailwindcss",
   "type": "module",


### PR DESCRIPTION
- 新增 Build and Release 工作流，用于在推送 v 开头的标签时自动构建和发布应用
- 配置支持 Windows 和 macOS 平台的构建
- 使用 Node.js 20 和 yarn 安装依赖
- 通过 Electron Builder 构建和发布应用，使用 GitHub 提供的 Token 进行认证
- 更新应用版本号至 1.0.2